### PR TITLE
Allow tag to be placed anywhere

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,15 +46,6 @@ module.exports = {
           <noscript> is now the only tag option.
         `);
       }
-
-      if ('placeIn' in appConfig.noScript) {
-        if (!['head', 'body'].includes(appConfig.noScript.placeIn)) {
-          this.ui.writeWarnLine(`ember-noscript
-          "${appConfig.noScript.placeIn}" is not a valid option for noScript placeIn option.
-          Specify "head" or "body".
-        `);
-        }
-      }
     }
   }
 };


### PR DESCRIPTION
Aside from head and body ember provides a head-footer and body-footer
along with allowing users to define custom content-for tags in
index.html so we shouldn't restrict this tag to only going in one place.